### PR TITLE
Reduce timeout module.

### DIFF
--- a/agent/metasploit_agent.py
+++ b/agent/metasploit_agent.py
@@ -25,7 +25,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-MODULE_TIMEOUT = 300
+MODULE_TIMEOUT = 30
 VULNERABLE_STATUSES = ["vulnerable", "appears"]
 METASPLOIT_AGENT_KEY = b"agent_metasploit_asset"
 REFERENCES = {


### PR DESCRIPTION
Module checks should not take more than seconds. We spend 5 min retrying the module check when the requests time out.